### PR TITLE
Solved makdown heading rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # FabAcademy_Template
 An html/ajax template for the students of Fab Academy
 
-## License
+## License
 MIT
 
-## Includes
+## Includes
 * <a href="http://getbootstrap.com/">Twitter Bootstrap</a>
 * <a href="http://jquery.com/">JQuery</a>
 * <a href="https://code.google.com/p/google-code-prettify/">google-code-prettify</a>
@@ -12,5 +12,5 @@ MIT
 * <a href="https://code.google.com/p/jsc3d/">JSC3D</a>
 * <a href="https://github.com/thegrubbsian/jquery.ganttView">jquery.ganttView</a>
 
-## Notes
+## Notes
 Ajax functionalities won't work locally on Chrome because of "safety settings" (but will work online).


### PR DESCRIPTION
Hi,
I've solved the issue with the heading rendering in Markdown :D
See the image!

<img width="918" alt="schermata 2018-01-22 alle 18 17 15" src="https://user-images.githubusercontent.com/8146506/35234221-a13acb56-ffa0-11e7-8161-ce237bf89338.png">

Sorry, but I hate to see the `#`!!

